### PR TITLE
add node types, add readme content, fix try binary block_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# migrate-outline-to-notion
+# Migrate Outline to Notion
 Migration tool to migrate from outline to notion
+
+# Set up an API key for notion
+Go to [https://www.notion.so/profile/integrations](https://www.notion.so/profile/integrations) and create a new internal integration. You will need `Internal Integration Secret` later.
+
+# Connect a page with the integration
+For the integration to have access to a page, you have to connect the integration to a certain page.
+Navigate to the page you want to import your Outline files, and in the page on the very top right corner, click the three dots (...) -> Connections -> \<your integration name\>, click and connect it.
+
+# Export outline 
+Go to [https://\<your-outline-ur\>/settings/export](https://\<your-outline-ur\>/settings/export) with your admin account and export all data as Markdown. You will get an email with the download link. Download the archived files, and export its contents somewhere on your local machine.
+
+# Set up env variables
+Create a .env file in this repository, and set following environment variables:
+- NOTION_API_KEY: `Internal Integration Secret` from your integration
+- NOTION_DESTINATION_PAGE_ID: the id of the page you want to import outline data in. It is the UUID part in the Notion page link, without "-" characters. For example, for `https://www.notion.so/test-page-1ad84dabc4ba976eb15be333148cc4c6`, id is going to be `1ad84dabc4ba976eb15be333148cc4c6`
+- OUTLINE_EXPORT_PATH: path of the folder on your machine in that you exported the Outline data from the archive.
+
+# Start the script
+- Install npm packages with `npm install`
+- run the script `npm run migrate`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@notionhq/client": "^2.2.14",
         "@tryfabric/martian": "^1.2.4",
         "ts-node": "^10.9.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.9"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -127,12 +130,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.13.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -895,9 +898,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "@notionhq/client": "^2.2.14",
     "@tryfabric/martian": "^1.2.4",
     "ts-node": "^10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.9"
   }
 }

--- a/src/bin/try.ts
+++ b/src/bin/try.ts
@@ -4,7 +4,7 @@ const notion = new Client({ auth: process.env.NOTION_API_KEY });
 
 async function main() {
     const response = await notion.blocks.children.list({
-        block_id: "144aa724-fdce-805d-a123-c60d77af41e5"//process.env.NOTION_DESTINATION_PAGE_ID,
+        block_id: process.env.NOTION_DESTINATION_PAGE_ID,
     });
     console.log(JSON.stringify(response, null, 2));
 }


### PR DESCRIPTION
Hi @olaurendeau ,

I used the tool to migrate our Outline instance to Notion and it worked like charm, thank you for implementing such a tool, it saved me a lot of time :)

I did some changes to improve it more.
- added node types in `devDependencies`, I got an error without it
- I had to read the code and search into the Notion documentation to find out how it actually works. So added a simple readme page for others to read and follow instructions
- fixed `try.ts` hat it takes block id from the env variable instead of hardcoded string.